### PR TITLE
modified in order to ignore test-reports.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Test Reports
+test-reports.xml


### PR DESCRIPTION
test-report.xml is generated when you run test.js, it isn't a source file and shouldn't be included in the repository.  So I propose to modify .gitignore file to ignore it.
